### PR TITLE
Add datasets to `PRIORITIES` list

### DIFF
--- a/stjudecloud_utilities/deduplicate_feature_counts.py
+++ b/stjudecloud_utilities/deduplicate_feature_counts.py
@@ -11,6 +11,8 @@ store = defaultdict(list)
 
 LOG = False
 BAD_FILES_FOLDER = "/bad-files/"
+# This list of priorities needs to be updated as new datasets are released.
+# The list of datasets can be found from the databrowser, looking at datasets with counts data.
 PRIORITIES = [
     "Clinical Pilot",
     "Pediatric Cancer Genome Project (PCGP)",
@@ -22,6 +24,12 @@ PRIORITIES = [
     "Pediatric Brain Tumor Program (PBTP)",
     "Pediatric Acute Myeloid Leukemia (PedAML)",
     "Genomics and transcriptomics of relapsed pediatric AML (RPAML)",
+    "Landscape of Pediatric Acute Myeloid Leukemia (PanpAML)",
+    "Atypical teratoid/rhabdoid tumor-derived tumoroid models (ATRT_TM)",
+    "Medulloblastoma Preclinical Ribociclib and Paxalisib (MBPRP)",
+    "Medulloblastoma Preclinical Ribociclib and Gemcitabine (MBPRG)",
+    "Pediatric Acute Myeloid Leukemia (PedAML)",
+    "CICERO Benchmark",
 ]
 
 

--- a/stjudecloud_utilities/deduplicate_feature_counts.py
+++ b/stjudecloud_utilities/deduplicate_feature_counts.py
@@ -133,7 +133,7 @@ def get_best_file(
 def main():
     parser = argparse.ArgumentParser(
         description="Deduplicates samples in DNAnexus based on the project priority " + \
-             "the St. Jude Cloud team uses."
+            "the St. Jude Cloud team uses."
     )
     parser.add_argument("dxids", nargs="+", type=str, help="DNAnexus file ids to deduplicate")
     args = parser.parse_args()


### PR DESCRIPTION
This PR adds datasets with feature counts on Genomics Platform, to the `PRIORITIES` list. I added the datasets in reverse chronological order as I assumed samples in newer datasets would be preferred over older datasets, for these non-clinical datasets.